### PR TITLE
beryllium: Revert DT url and switch to dev branch

### DIFF
--- a/devices_dep.json
+++ b/devices_dep.json
@@ -18,9 +18,9 @@
    ],
    "beryllium":[
       {
-         "url":"https://github.com/shreejoy/android_device_xiaomi_beryllium",
+         "url":"https://github.com/AxelBlaz3/android_device_xiaomi_beryllium",
          "target_path":"device/xiaomi/beryllium",
-         "branch":"lineage-16.0"
+         "branch":"dev"
       },
       {
          "url":"https://github.com/AOSiP-Devices/device_xiaomi_sdm845-common",


### PR DESCRIPTION
Branch switching is temporary, once everything is fixed, we'll get back to stable branch (lineage-16.0)