### PR TITLE
violet: Use azure-clang

### DIFF
--- a/devices_dep.json
+++ b/devices_dep.json
@@ -148,9 +148,9 @@
          "branch":"ten"
       },
       {
-         "url":"https://github.com/kdrag0n/proton-clang",
+         "url":"https://github.com/Panchajanya1999/azure-clang",
          "target_path":"prebuilts/clang/host/linux-x86/clang-11",
-         "branch":"master"
+         "branch":"inline"
       }
    ],
    "tissot":[


### PR DESCRIPTION
Proton clang gave few issues while compilation. So switch it.

Change-Id: I6f3416f74a92b8a9031b044674cb3c6b7d073a1d
Signed-off-by: Panchajanya1999 <panchajanya@azure-dev.live>