### PR TITLE
ginkgo:track clang 11.0

### DIFF
--- a/devices_dep.json
+++ b/devices_dep.json
@@ -545,6 +545,11 @@
          "url":"https://github.com/trinket-devs/kernel_xiaomi_ginkgo.git",
          "target_path":"kernel/xiaomi/ginkgo",
          "branch":"10.0"
-      }
+      },
+      {
+         "url":"https://github.com/trinket-devs/proton-clang.git",
+         "target_path":"prebuilts/clang/host/linux-x86/clang-11.0",
+         "branch":"master"
+      } 
    ]
 }


### PR DESCRIPTION
needed by kernel for lto